### PR TITLE
Force word wrap in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.wordWrap": "on"
+}


### PR DESCRIPTION
１行の文字がVS Code上ではみ出したときに、スクロールでなくwrapして表示するように強制するものです。