### PR TITLE
Fix typo and remove unfold HasDerivAt

### DIFF
--- a/Tutorial/Advanced/Analysis/Lecture1.lean
+++ b/Tutorial/Advanced/Analysis/Lecture1.lean
@@ -211,7 +211,6 @@ variable {g : ℝ → ℝ} {g' : ℝ}
 /-- 合成関数の微分 -/
 theorem HasDerivAt.comp (hf : HasDerivAt f f' a) (hg : HasDerivAt g g' (f a)) : 
     HasDerivAt (g ∘ f) (g' * f') a := by
-  rw [hasDerivAt_iff_isLittleO] at *
   have h₁ := 
     calc (fun x ↦ g (f x) - g (f a) - (f x - f a) * g') 
         =o[𝓝 a] fun x ↦ f x - f a                := ?eq1

--- a/Tutorial/Advanced/Analysis/Lecture2.lean
+++ b/Tutorial/Advanced/Analysis/Lecture2.lean
@@ -47,7 +47,7 @@ theorem IsLocalMax.hasDerivAt_eq_zero (h : IsLocalMax f a) (hf : HasDerivAt f f'
   -- `f' ≤ 0`と`0 ≤ f'`を示す。
   apply le_antisymm ?right ?left
   case right =>
-    -- `x`を`a`に右側から近づけたとき`(f x - f a) / (x - a)`は`f`に収束する。
+    -- `x`を`a`に右側から近づけたとき`(f x - f a) / (x - a)`は`f'`に収束する。
     have hf : Tendsto (fun x ↦ (f x - f a) / (x - a)) (𝓝[>] a) (𝓝 f') := by
       rw [hasDerivAt_iff_tendsto_slope] at hf
       apply hf.mono_left (nhds_right'_le_nhds_ne a)


### PR DESCRIPTION
- `Analysis/Lecture2`の微分についての明らかな誤字修正
- 合成関数の微分の問題で、最初に`HasDerivAt`を展開してしまうよりそのまま`HasDerivAt`を残したほうが、上で示した`hf.continuousAt`や`isBigO_sub`を使うときに見やすい気がします。